### PR TITLE
Fixes WatchJs Dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
     const BrowserWindow = Electron.BrowserWindow;
     const EventEmitter = new (require('events').EventEmitter);
     const FileSystem = require('fs');
-    const WatchJS = require('watchjs');
+    const WatchJS = require('melanke-watchjs');
     const Shortcuts = require('electron-localshortcut');
     const _ = require('underscore');
 


### PR DESCRIPTION
Should fix #26 

- Changed package.json to pull from npm "melanke-watchjs" instead of the GIT url
- Changed index.js to require "watchjs" as specified in the watchjs documentation