### PR TITLE
Fixes import of watchjs module

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
     const BrowserWindow = Electron.BrowserWindow;
     const EventEmitter = new (require('events').EventEmitter);
     const FileSystem = require('fs');
-    const WatchJS = require('melanke-watchjs');
+    const WatchJS = require('watchjs');
     const Shortcuts = require('electron-localshortcut');
     const UrlPath = require('url');
     const DirPath = require('path');


### PR DESCRIPTION
Electron fails with `Error: Cannot find module 'melanke-watchjs'`  

The docs for Watch.JS show `require("watchjs")` rather than `require("melanke-watchjs")`. https://github.com/melanke/Watch.JS/blob/master/README.md#nodejs-require