### PR TITLE
keep window reference when closing, fixed documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ You probably wont be needing this method, but it's here just in case.
 **But don't try to use the above code, `Window` isn't available in your app scope**, use `windowManager.createNew/open` instead, and as you can see the arguments are the same in the 3 cases, **check out [windowManager.createNew](#createnew-name-title-url-setuptemplate-setup-showdevtools-) for more info on the arguments**.
 
 ### `Window.name` 
-Stores the widnow name.
+Stores the window name.
 
 ### `Window.setup` 
 Stores the window setup object.

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@
             console.log('Window "' + instance.name + '" was closed');
 
             // Delete the reference on the windowManager object
-            delete windowManager.windows[instance.name];
+            //delete windowManager.windows[instance.name];
 
             // Delete the window object
             instance.object = null;


### PR DESCRIPTION
Closing a window should not delete it's reference, this causes unexpected behavior when trying to re-open it later.