### PR TITLE
Added menu support to macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
 const Electron = require('electron');
 const Application = Electron.app;
 const BrowserWindow = Electron.BrowserWindow;
+const Menu = Electron.Menu;
 const EventEmitter = new (require('events').EventEmitter);
 const FileSystem = require('fs');
 const WatchJS = require('melanke-watchjs');
@@ -195,7 +196,11 @@ Window.prototype.create = function(url) {
 
     // Set the window menu (null is valid to not have a menu at all)
     if(this.setup.menu !== undefined){
-        this.object.setMenu(this.setup.menu);
+        if(process.platform === 'darwin') {
+          Menu.setApplicationMenu(Menu.buildFromTemplate(this.setup.menu));
+        } else {
+          this.object.setMenu(this.setup.menu);
+        }
     }
 
     // Show the dev tools ?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-window-manager",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A NodeJs module that handles window management for Electron (Atom Shell, previously)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a small change that brings the underlying source code into alignment with the documentation. 

On macOS, the `setMenu` method is [unavailable for any Browser Window](https://electronjs.org/docs/api/menu#setting-menu-for-specific-browser-window-linux-windows). Instead, you use the `setApplicationMenu` to produce the appropriate menu for the entire application.  

I've also included Electron's `menu`, and moved the `Menu.buildFromTemplate()` into this module, so that electron-window-manager takes care of this process completely.

This approach will work with multiple window templates if they are open and closed independently. However, due to macOS only having a single application menu. As there is a single application menu, every time `setApplicationMenu` is called, it overwrites the previous config. This PR allows you to set menus on macOS but may only allow for one Application Menu at a time, even if two window templates are currently loaded and displayed.