### PR TITLE
event onLoadFailure should know parameters from did-fail-load

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,8 +174,10 @@
         console.log('Window "' + this.name + '" was created');
 
         // On load failure
-        this.object.webContents.on('did-fail-load', function(){
-            instance.down();
+        this.object.webContents.on('did-fail-load', function(event, errorCode, errorDescription, validatedURL, isMainFrame, frameProcessId, frameRoutingId){
+            if (isMainFrame) {
+                instance.down({event, errorCode, errorDescription, validatedURL, isMainFrame});
+            }
         });
 
         // If the width/height not provided!
@@ -313,7 +315,7 @@
      * Triggers the load-failure callback. This method is called whenever the targeted content isn't available or
      * accessible. It will display a custom message by default, unless you define a custom callback for the window
      * */
-    Window.prototype.down = function(){
+    Window.prototype.down = function(didFailParams){
         // Force ignore the layout!
         this.setup.layout = false;
 
@@ -321,7 +323,7 @@
         var callback = this.setup.onLoadFailure || windowManager.config.onLoadFailure;
 
         // Trigger the call back
-        callback.call(null, this);
+        callback.call(null, this, didFailParams);
     };
 
     /**


### PR DESCRIPTION
* Electron `did-fail-load` may fire on any script on loaded page
* for example `errorCode===-3` (Aborted) could happen when some script is still downloading and page starts to navigate elsewhere
* this change will provide all available parameters from `did-fail-load` to `onLoadFailure` event handler as second parameter
* I based my branch on latest 1.0.6 release, but it should be merget also to master

Example:
```javascript
onLoadFailure: function (window, didFailParams) 
    if (didFailParams && (!didFailParams.isMainFrame || didFailParams.errorCode === -3)) {
      log.debug(`onLoadFailure ignored: ${didFailParams.validatedURL}`)
      return
    }
  // ...
}
```