### PR TITLE
fixed a bug of sharedData.fetch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1074,7 +1074,7 @@ const windowManager = {
          * @param altValue The alternative value to return in case the passed key doesn't exist
          * */
         'fetch': function(key, altValue){
-            return this.data[key] ?this.data[key] :altValue;
+            return (this.data[key] !== undefined) ?this.data[key] :altValue;
         },
 
         /**


### PR DESCRIPTION
You can't use `0` / `false` for `sharedData` due to invalid check.
Currently the workaround is to provide `altValue` explicitly, such as
```
const d = windowmanager.sharedData.fetch('key', 0);
```

But of course, you may not use anything other than `0` / `false` as `altValue` if your `value` would have `0` or `false`.
(for instance, your value would be `0` ~ `100` and you want to give `MAX_VALUE` if the key doesn't exist --- you won't be able to solve this situation with the above workaround)

